### PR TITLE
FIX: Fixed issue with FindWindowA();

### DIFF
--- a/boogetProject1/main.cpp
+++ b/boogetProject1/main.cpp
@@ -24,7 +24,8 @@ bool toggleRightClicker = true;
 bool hideClicker = true;
 
 int main() {
-	HWND hwnd = FindWindowA(NULL, "LWJGL");
+	HWND hwnd = FindWindowA("LWJGL", nullptr);
+	
 	if (hwnd == NULL) {
 		std::cout << "Minecraft was not found!";
 		Sleep(2000);

--- a/boogetProject1/main.cpp
+++ b/boogetProject1/main.cpp
@@ -80,6 +80,9 @@ int main() {
 			else if (hideClicker) {
 				::ShowWindow(::GetConsoleWindow(), SW_SHOW);
 			}
+
+			threadSleep(200);
+			// This will stop it from spamming if you hold down insert.
 		}
 	}
 }

--- a/boogetProject1/menu.cpp
+++ b/boogetProject1/menu.cpp
@@ -13,9 +13,11 @@
 
 #include "menu.h"
 
+
 void menu() {
-	system("CLS");
-	SetConsoleTitle("Booget Clicker");
+	system("CLS"); // This is not best practice but works.
+	
+	SetConsoleTitleA("Booget Clicker");
 	HWND hwndCmd = GetConsoleWindow();
 	if (hwndCmd != NULL) { MoveWindow(hwndCmd, 340, 550, 340, 210, TRUE); }
 	SetWindowLong(hwndCmd, GWL_STYLE, GetWindowLong(hwndCmd, GWL_STYLE) & ~WS_MAXIMIZEBOX & ~WS_SIZEBOX);


### PR DESCRIPTION
Fixed issue with `FindWindowA();` now correctly finds Minecraft window.
also added a delay to hideWindow because holding the key will result in it spamming open/close
way to fast, now with the delay its a lot easier to toggle.